### PR TITLE
Fix for NamedList conversion regression

### DIFF
--- a/src/flux/response.clj
+++ b/src/flux/response.clj
@@ -7,6 +7,12 @@
 
 ;; TODO: Rename this ns to something like "conversion", not "response"
 
+(defn convert-key
+  [k]
+  (if (string? k)
+    (keyword k)
+    k))
+
 (defmulti ->clojure class)
 
 (defmethod ->clojure SimpleOrderedMap [^SimpleOrderedMap obj]
@@ -17,9 +23,10 @@
    (iterator-seq (.iterator obj))))
 
 (defmethod ->clojure NamedList [^NamedList obj]
-  (mapv
-   (fn [^java.util.Map$Entry o] (vector (.getKey o) (->clojure (.getValue o))))
-   (iterator-seq (.iterator obj))))
+  (into {}
+        (mapv
+         (fn [^java.util.Map$Entry o] (vector (convert-key (.getKey o)) (->clojure (.getValue o))))
+         (iterator-seq (.iterator obj)))))
 
 (defmethod ->clojure ArrayList [obj]
   (mapv ->clojure obj))

--- a/test/flux/unit/response.clj
+++ b/test/flux/unit/response.clj
@@ -1,4 +1,5 @@
 (ns flux.unit.response
+  (:import [org.apache.solr.common.util NamedList])
   (:require [flux.update :as update]
             [flux.response :refer :all]
             [midje.sweet :refer :all]))
@@ -6,3 +7,7 @@
 (fact "create-map-from-document"
   (let [doc (update/create-doc {:id 1})]
     (->clojure doc) => {:id 1}))
+
+(fact "Convert named list"
+  (let [nl (NamedList. (into-array {"a" 1 "b" 2}))]
+    (->clojure nl) => {:a 1 :b 2}))


### PR DESCRIPTION
- Commit 62ae93e introduced a regression when converting NamedList
  objects
- In previous version, covert-named-list returned a map with string
  keys converted to keywords
- The new ->clojure multi method will return a vector of 2-element
  vectors when called on a NamedList (string keys not converted)
- Unit test provided to illustrate issue
