### PR TITLE
added a collections reload and list method, create connection with URL arg alone

### DIFF
--- a/src/flux/collections.clj
+++ b/src/flux/collections.clj
@@ -73,8 +73,17 @@
       (Thread/sleep 1000)
       (recur (try-all-replicas connection collection)))))
 
+(defn- collection-crud
+  "CRUD helper for collections "
+  [connection params]
+  (client/request
+   connection
+   (q/create-query-request :get "/admin/collections" params)))
+
 (defn create-collection
   "Create a SolrCloud collection"
+  ([connection collection-name]
+   (create-collection connection collection-name 1 1 {}))
   ([connection collection-name num-shards]
    (create-collection connection collection-name num-shards 1 {}))
   ([connection collection-name num-shards replication-factor]
@@ -85,14 +94,19 @@
                             "name" collection-name
                             "numShards" num-shards
                             "replicationFactor" replication-factor)]
-     (client/request
-      connection
-      (q/create-query-request :get "/admin/collections" with-params)))))
+     (collection-crud connection with-params))))
 
 (defn delete-collection
   "Delete a SolrCloud collection"
   [connection collection-name]
-  (let [with-params {"action" "delete" "name" collection-name}]
-    (client/request
-     connection
-     (q/create-query-request :get "/admin/collections" with-params))))
+  (collection-crud connection {"action" "delete" "name" collection-name}))
+
+(defn reload-collection
+  "Reloads a SolrCloud collection"
+  [connection collection-name]
+  (collection-crud connection {"action" "reload" "name" collection-name}))
+
+(defn list-collections
+  "Lists all the Solr collections"
+  [connection]
+  (collection-crud connection {"action" "list"}))

--- a/src/flux/http.clj
+++ b/src/flux/http.clj
@@ -1,5 +1,7 @@
 (ns flux.http
   (import [org.apache.solr.client.solrj.impl HttpSolrServer]))
 
-(defn create [base-url core-name]
-  (HttpSolrServer. (str base-url "/" (name core-name))))
+(defn create
+  ([base-url] (create base-url ""))
+  ([base-url core-name]
+  (HttpSolrServer. (str base-url "/" (name core-name)))))


### PR DESCRIPTION
For creating a collection, we first need a connection. 

```clojure
(def myconn (http/create "http://localhost:8983/solr"  "mycollection" )
(create-collection myconn "mycollection" 1 )
```

However, this gives me an error (on Solr version 4.10.2)  

>org.apache.solr.client.solrj.impl.HttpSolrServer$RemoteSolrException: Expected mime type application/octet-stream but got text/html.  
**(html elided)**
>Problem accessing /solr/mycollection/admin/collections. 


We can instead specify a connection that only takes a URL, and returns a connection, which can be used to create a collection. 
I've also added 2 methods for listing and reloading collections.

```clojure
(def myconn (http/create "http://localhost:8983/solr" ))
(flux-col/create-collection myconn "mycollection" 1 )
(flux-col/list-collections myconn )
;add documents
(flux-col/reload-collection myconn "mycollection")
(flux-col/delete-collection myconn "mycollection" )
```