### PR TITLE
add support for hierarcical document.

### DIFF
--- a/src/flux/update.clj
+++ b/src/flux/update.clj
@@ -5,10 +5,14 @@
 ;; which throws an exception when printed!
 (defn create-doc ^SolrInputDocument [document-map]
   (reduce-kv (fn [^SolrInputDocument doc k v]
-               (if (map? v)
+               (cond
+                 (= k :_childDocuments_)
+                 (doto doc (.addChildDocuments (map create-doc v)))
+                 (map? v)
                  (let [m (doto (java.util.HashMap.)
                            (.put (name (key (first v))) (val (first v))))]
                    (doto doc (.addField (name k) m))
                    doc)
+                 :else
                  (doto doc (.addField (name k) v))))
              (SolrInputDocument.) document-map))

--- a/test/flux/unit/update.clj
+++ b/test/flux/unit/update.clj
@@ -1,6 +1,18 @@
 (ns flux.unit.update
   (:require [flux.update :refer :all]
-            [midje.sweet :refer :all]))
+            [midje.sweet :refer :all])
+  (:import [org.apache.solr.common SolrInputDocument]))
 
 (fact "create-doc"
   (class (create-doc {:id 1})) => org.apache.solr.common.SolrInputDocument)
+
+(fact "create-doc-with-children"
+  (let [doc { :id 1
+              :_childDocuments_
+              [{ :id "1.1"
+                 :title "a title..."
+                 :_childDocuments_
+                 [{:id "1.1.1"}]}]}
+        solr-doc (create-doc doc)]
+    (.hasChildDocuments solr-doc) => true
+    (-> solr-doc (.getChildDocuments) first (.hasChildDocuments)) => true))


### PR DESCRIPTION
SolrDocument.addChildren was never used. Now if the document contains a _childDocuments_ key, then  the vector will be added as a list of children to the current document. 

It works also recursively.